### PR TITLE
Add support for multiple document paths with glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ Create `config.json`:
 
 ```json
 {
-  "documents_dir": "./documents",
+  "document_patterns": [
+    "./documents",
+    "./notes/**/*.md",
+    "./projects/backend/**/*.md"
+  ],
   "db_path": "./vectors.db",
   "chunk_size": 500,
   "search_top_k": 5,
@@ -109,7 +113,11 @@ Create `config.json`:
 
 ### Configuration Options
 
-- `documents_dir`: Directory containing markdown files
+- `document_patterns`: Array of document paths and glob patterns
+  - Supports directory paths: `"./documents"`
+  - Supports glob patterns: `"./docs/**/*.md"` (recursive)
+  - Multiple patterns: Index files from different locations
+  - **Note**: Old `documents_dir` field is still supported (automatically migrated)
 - `db_path`: Vector database file path
 - `chunk_size`: Document chunk size in characters
 - `search_top_k`: Number of search results to return
@@ -117,6 +125,19 @@ Create `config.json`:
 - `compute.fallback_to_cpu`: Fallback to CPU if GPU unavailable
 - `model.name`: Embedding model name
 - `model.dimensions`: Vector dimensions
+
+### Pattern Examples
+
+```json
+{
+  "document_patterns": [
+    "./documents",                    // All .md files in documents/
+    "./notes/**/*.md",                // Recursive search in notes/
+    "./projects/*/docs/*.md",         // docs/ in each project
+    "/path/to/external/docs"          // Absolute path
+  ]
+}
+```
 
 ## MCP Tools
 
@@ -168,7 +189,11 @@ Configure for your project's docs directory:
 
 ```json
 {
-  "documents_dir": "./docs",
+  "document_patterns": [
+    "./docs",
+    "./api-docs/**/*.md",
+    "./wiki/**/*.md"
+  ],
   "db_path": "./.devrag/vectors.db"
 }
 ```
@@ -415,7 +440,11 @@ Claude Codeで：
 
 ```json
 {
-  "documents_dir": "./documents",
+  "document_patterns": [
+    "./documents",
+    "./notes/**/*.md",
+    "./projects/backend/**/*.md"
+  ],
   "db_path": "./vectors.db",
   "chunk_size": 500,
   "search_top_k": 5,
@@ -432,7 +461,11 @@ Claude Codeで：
 
 ### 設定項目
 
-- `documents_dir`: マークダウンファイルを配置するディレクトリ
+- `document_patterns`: ドキュメントのパスとglobパターンの配列
+  - ディレクトリパス対応: `"./documents"`
+  - globパターン対応: `"./docs/**/*.md"` (再帰的)
+  - 複数パターン: 異なる場所からファイルをインデックス化
+  - **注意**: 旧形式の`documents_dir`もサポート（自動的に移行）
 - `db_path`: ベクトルデータベースのパス
 - `chunk_size`: ドキュメントのチャンクサイズ（文字数）
 - `search_top_k`: 検索結果の返却件数
@@ -440,6 +473,19 @@ Claude Codeで：
 - `compute.fallback_to_cpu`: GPU利用不可時にCPUにフォールバック
 - `model.name`: 埋め込みモデル名
 - `model.dimensions`: ベクトル次元数
+
+### パターン例
+
+```json
+{
+  "document_patterns": [
+    "./documents",                    // documents/内の全.mdファイル
+    "./notes/**/*.md",                // notes/内を再帰的に検索
+    "./projects/*/docs/*.md",         // 各プロジェクトのdocs/
+    "/path/to/external/docs"          // 絶対パス
+  ]
+}
+```
 
 ## MCPツール
 
@@ -491,7 +537,11 @@ Model Context Protocolを通じて以下のツールを提供：
 
 ```json
 {
-  "documents_dir": "./docs",
+  "document_patterns": [
+    "./docs",
+    "./api-docs/**/*.md",
+    "./wiki/**/*.md"
+  ],
   "db_path": "./.devrag/vectors.db"
 }
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	fmt.Fprintf(os.Stderr, "[INFO] Configuration loaded successfully\n")
-	fmt.Fprintf(os.Stderr, "[INFO] Documents directory: %s\n", cfg.DocumentsDir)
+	fmt.Fprintf(os.Stderr, "[INFO] Document patterns: %v\n", cfg.DocumentPatterns)
 	fmt.Fprintf(os.Stderr, "[INFO] Database path: %s\n", cfg.DBPath)
 	fmt.Fprintf(os.Stderr, "[INFO] Model: %s (dimensions: %d)\n", cfg.Model.Name, cfg.Model.Dimensions)
 	fmt.Fprintf(os.Stderr, "[INFO] Device: %s\n", cfg.Compute.Device)
@@ -46,10 +46,12 @@ func main() {
 
 	// 4. Initialize components
 
-	// Ensure documents directory exists
-	if err := os.MkdirAll(cfg.DocumentsDir, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "[FATAL] Failed to create documents directory: %v\n", err)
-		os.Exit(1)
+	// Ensure base directories exist
+	baseDirs := cfg.GetBaseDirectories()
+	for _, dir := range baseDirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "[WARN] Failed to create directory %s: %v\n", dir, err)
+		}
 	}
 
 	// Initialize database

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,14 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 type Config struct {
-	DocumentsDir string `json:"documents_dir"`
-	DBPath       string `json:"db_path"`
-	ChunkSize    int    `json:"chunk_size"`
-	SearchTopK   int    `json:"search_top_k"`
-	Compute      struct {
+	// Deprecated: Use DocumentPatterns instead
+	DocumentsDir     string   `json:"documents_dir,omitempty"`
+	DocumentPatterns []string `json:"document_patterns,omitempty"`
+	DBPath           string   `json:"db_path"`
+	ChunkSize        int      `json:"chunk_size"`
+	SearchTopK       int      `json:"search_top_k"`
+	Compute          struct {
 		Device        string `json:"device"`
 		FallbackToCPU bool   `json:"fallback_to_cpu"`
 	} `json:"compute"`
@@ -24,10 +28,10 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	cfg := &Config{
-		DocumentsDir: "./documents",
-		DBPath:       "./vectors.db",
-		ChunkSize:    500,
-		SearchTopK:   5,
+		DocumentPatterns: []string{"./documents"},
+		DBPath:           "./vectors.db",
+		ChunkSize:        500,
+		SearchTopK:       5,
 	}
 	cfg.Compute.Device = "auto"
 	cfg.Compute.FallbackToCPU = true
@@ -61,11 +65,34 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("failed to read config: %w", err)
 	}
 
+	// First unmarshal to check which fields are present
+	var rawConfig map[string]interface{}
+	if err := json.Unmarshal(data, &rawConfig); err != nil {
+		fmt.Fprintf(os.Stderr, "[WARN] Invalid JSON in config.json: %v\n", err)
+		fmt.Fprintf(os.Stderr, "[WARN] Using default configuration\n")
+		return DefaultConfig(), nil
+	}
+
 	cfg := DefaultConfig()
 	if err := json.Unmarshal(data, cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "[WARN] Invalid JSON in config.json: %v\n", err)
 		fmt.Fprintf(os.Stderr, "[WARN] Using default configuration\n")
 		return cfg, nil
+	}
+
+	// Migrate old format to new format
+	_, hasOldField := rawConfig["documents_dir"]
+	_, hasNewField := rawConfig["document_patterns"]
+
+	if hasOldField && !hasNewField {
+		fmt.Fprintf(os.Stderr, "[INFO] Migrating from documents_dir to document_patterns\n")
+		cfg.DocumentPatterns = []string{cfg.DocumentsDir}
+		cfg.DocumentsDir = "" // Clear deprecated field
+	}
+
+	// Validate that at least one pattern is configured
+	if len(cfg.DocumentPatterns) == 0 {
+		cfg.DocumentPatterns = []string{"./documents"}
 	}
 
 	fmt.Fprintf(os.Stderr, "[INFO] Loaded configuration from %s\n", configFile)
@@ -97,5 +124,210 @@ func (c *Config) Validate() error {
 	if c.Model.Dimensions <= 0 {
 		return fmt.Errorf("model.dimensions must be positive")
 	}
+	if len(c.DocumentPatterns) == 0 {
+		return fmt.Errorf("at least one document pattern must be specified")
+	}
 	return nil
+}
+
+// GetDocumentFiles expands all document patterns and returns matching markdown files
+func (c *Config) GetDocumentFiles() ([]string, error) {
+	files := make(map[string]bool) // Use map to deduplicate
+
+	for _, pattern := range c.DocumentPatterns {
+		matches, err := c.expandPattern(pattern)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[WARN] Failed to expand pattern %s: %v\n", pattern, err)
+			continue
+		}
+		for _, match := range matches {
+			files[match] = true
+		}
+	}
+
+	// Convert map to slice
+	result := make([]string, 0, len(files))
+	for file := range files {
+		result = append(result, file)
+	}
+
+	return result, nil
+}
+
+// expandPattern expands a single pattern to matching markdown files
+// Supports both directory paths (e.g., "./docs") and glob patterns (e.g., "./docs/**/*.md")
+func (c *Config) expandPattern(pattern string) ([]string, error) {
+	var files []string
+
+	// Check if pattern looks like a directory (no wildcards and no .md extension)
+	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+		// Treat as directory - walk it for all .md files
+		err := filepath.Walk(pattern, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil // Continue despite errors
+			}
+			if !info.IsDir() && filepath.Ext(path) == ".md" {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return files, nil
+	}
+
+	// Pattern contains wildcards - need to handle ** specially
+	if strings.Contains(pattern, "**") {
+		return c.expandDoubleStarPattern(pattern)
+	}
+
+	// Simple glob pattern (no **)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter to only markdown files
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() && filepath.Ext(match) == ".md" {
+			files = append(files, match)
+		}
+	}
+
+	return files, nil
+}
+
+// expandDoubleStarPattern handles patterns with ** (recursive directory matching)
+func (c *Config) expandDoubleStarPattern(pattern string) ([]string, error) {
+	var files []string
+
+	// Split pattern at **
+	parts := strings.SplitN(pattern, "**", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ** pattern: %s", pattern)
+	}
+
+	baseDir := parts[0]
+	suffix := parts[1]
+
+	// Clean up baseDir
+	if baseDir == "" {
+		baseDir = "."
+	} else {
+		baseDir = strings.TrimSuffix(baseDir, string(filepath.Separator))
+	}
+
+	// Walk the base directory
+	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Continue despite errors
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Check if path matches the suffix pattern
+		if c.matchesSuffix(path, baseDir, suffix) {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+// matchesSuffix checks if a file path matches the suffix pattern after **
+func (c *Config) matchesSuffix(path, baseDir, suffix string) bool {
+	// Remove baseDir from path
+	relPath, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return false
+	}
+
+	// If suffix is empty or just a separator, match all .md files
+	if suffix == "" || suffix == string(filepath.Separator) || suffix == "/" {
+		return filepath.Ext(path) == ".md"
+	}
+
+	// Clean suffix
+	suffix = strings.TrimPrefix(suffix, string(filepath.Separator))
+	suffix = strings.TrimPrefix(suffix, "/")
+
+	// If suffix is just *.md, match all markdown files
+	if suffix == "*.md" {
+		return filepath.Ext(path) == ".md"
+	}
+
+	// Check if relPath matches the suffix pattern
+	matched, err := filepath.Match(suffix, filepath.Base(relPath))
+	if err != nil {
+		return false
+	}
+
+	if matched && filepath.Ext(path) == ".md" {
+		return true
+	}
+
+	// For patterns like "subdir/*.md", check full relative path
+	matched, err = filepath.Match(suffix, relPath)
+	if err != nil {
+		return false
+	}
+
+	return matched && filepath.Ext(path) == ".md"
+}
+
+// GetBaseDirectories returns the base directories from all patterns
+// This is useful for path validation
+func (c *Config) GetBaseDirectories() []string {
+	dirs := make(map[string]bool)
+
+	for _, pattern := range c.DocumentPatterns {
+		// Extract base directory from pattern
+		baseDir := c.extractBaseDir(pattern)
+		if baseDir != "" {
+			absDir, err := filepath.Abs(baseDir)
+			if err == nil {
+				dirs[absDir] = true
+			}
+		}
+	}
+
+	result := make([]string, 0, len(dirs))
+	for dir := range dirs {
+		result = append(result, dir)
+	}
+
+	return result
+}
+
+// extractBaseDir extracts the base directory from a pattern
+func (c *Config) extractBaseDir(pattern string) string {
+	// Find the first wildcard
+	wildcardIndex := strings.IndexAny(pattern, "*?")
+	if wildcardIndex == -1 {
+		// No wildcards - entire pattern is base directory
+		return pattern
+	}
+
+	// Get the directory part before the wildcard
+	baseDir := pattern[:wildcardIndex]
+	baseDir = filepath.Dir(baseDir)
+
+	if baseDir == "." {
+		return baseDir
+	}
+
+	return baseDir
 }


### PR DESCRIPTION
### **User description**
This enhancement allows users to specify multiple document directories and glob patterns in config.json, providing more flexibility in organizing and indexing markdown files.

Features:
- Config: Changed from single 'documents_dir' to 'document_patterns' array
- Supports both directory paths and glob patterns (e.g., "./docs/**/*.md")
- Backwards compatible: old 'documents_dir' automatically migrated
- Sync: Uses pattern matching to find files instead of single directory walk
- MCP tools: Updated path validation to work with multiple base directories
- Tests: Added comprehensive tests for pattern expansion and migration
- Documentation: Updated README with examples and pattern syntax

Example config.json:
{
  "document_patterns": [ "./documents", "./notes/**/*.md", "./projects/backend/**/*.md" ], ... }

Pattern examples:
- "./documents" - All .md files in directory
- "./docs/**/*.md" - Recursive search with **
- "./projects/*/docs/*.md" - Wildcard patterns
- "/path/to/external/docs" - Absolute paths


___

### **PR Type**
Enhancement


___

### **Description**
- Replace single `documents_dir` with `document_patterns` array for flexible multi-location indexing

- Support glob patterns including `**` for recursive directory matching

- Implement backwards compatibility with automatic migration from old config format

- Add comprehensive pattern expansion logic with deduplication across multiple patterns

- Update path validation in MCP tools to work with multiple base directories

- Enhance test coverage with pattern expansion and migration scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config: documents_dir"] -->|"Migrate"| B["Config: document_patterns[]"]
  B -->|"Expand patterns"| C["GetDocumentFiles"]
  C -->|"Match globs & dirs"| D["Markdown files list"]
  D -->|"Deduplicate"| E["Final file set"]
  B -->|"Extract base dirs"| F["GetBaseDirectories"]
  F -->|"Validate paths"| G["MCP tools"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Update main to support multiple document directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/main.go

<ul><li>Updated logging to display <code>DocumentPatterns</code> array instead of single <br><code>DocumentsDir</code><br> <li> Changed directory creation logic to iterate over multiple base <br>directories from <code>GetBaseDirectories()</code><br> <li> Converted fatal error to warning for individual directory creation <br>failures</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/2/files#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add glob pattern support with backwards compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config.go

<ul><li>Added <code>DocumentPatterns</code> field as array and deprecated <code>DocumentsDir</code> <br>field<br> <li> Implemented <code>GetDocumentFiles()</code> to expand all patterns and return <br>deduplicated markdown files<br> <li> Added <code>expandPattern()</code> to handle both directory paths and glob patterns<br> <li> Implemented <code>expandDoubleStarPattern()</code> for recursive <code>**</code> pattern <br>matching<br> <li> Added <code>GetBaseDirectories()</code> to extract base directories from patterns <br>for path validation<br> <li> Implemented backwards compatibility migration in <code>Load()</code> function<br> <li> Enhanced <code>Validate()</code> to ensure at least one document pattern is <br>configured</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/2/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cd">+241/-9</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync.go</strong><dd><code>Use pattern-based file discovery instead of directory walk</code></dd></summary>
<hr>

internal/indexer/sync.go

<ul><li>Replaced <code>filepath.Walk()</code> on single directory with <code>GetDocumentFiles()</code> <br>call<br> <li> Simplified file scanning logic by delegating pattern matching to <br>config<br> <li> Improved error handling to continue processing despite individual file <br>access errors</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/2/files#diff-fc633346efad6133f00c66cf7004ac41d5b3fbd196c6f2a8c6e0009eee2ff496">+12/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tools.go</strong><dd><code>Update path validation for multiple base directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/mcp/tools.go

<ul><li>Updated <code>validatePath()</code> to accept multiple base directories array<br> <li> Fixed path validation logic to check if file is within any configured <br>base directory<br> <li> Updated <code>handleDeleteDocument()</code> and <code>handleReindexDocument()</code> to use full <br>file paths<br> <li> Updated <code>handleIndexMarkdown()</code>, <code>handleAddFrontmatter()</code>, and <br><code>handleUpdateFrontmatter()</code> to use <code>GetBaseDirectories()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/2/files#diff-7c0d527ba4a221ad07c68fbba6d86758d527c2332590fa5758195e17ba3075a0">+25/-22</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_test.go</strong><dd><code>Add comprehensive tests for pattern expansion and migration</code></dd></summary>
<hr>

internal/config/config_test.go

<ul><li>Updated existing tests to use <code>DocumentPatterns</code> array instead of <br><code>DocumentsDir</code><br> <li> Added <code>TestLoadConfig_BackwardsCompatibility()</code> to verify migration from <br>old format<br> <li> Added <code>TestGetDocumentFiles()</code> with multiple test cases for pattern <br>expansion<br> <li> Added <code>TestGetBaseDirectories()</code> to validate base directory extraction<br> <li> Added helper functions <code>contains()</code> and <code>containsMiddle()</code> for flexible <br>string matching</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/2/files#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62">+198/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document glob pattern support and configuration examples</code>&nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated configuration examples to use <code>document_patterns</code> array with <br>multiple patterns<br> <li> Added documentation for pattern syntax including directory paths and <br>glob patterns<br> <li> Added new "Pattern Examples" section with detailed examples<br> <li> Updated configuration options description with pattern capabilities<br> <li> Added note about backwards compatibility with old <code>documents_dir</code> field<br> <li> Updated all code examples throughout English and Japanese sections</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+56/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

