### PR TITLE
Add --config CLI flag to specify custom configuration file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ Create `config.json`:
 
 ```json
 {
-  "documents_dir": "./documents",
+  "document_patterns": [
+    "./documents",
+    "./notes/**/*.md",
+    "./projects/backend/**/*.md"
+  ],
   "db_path": "./vectors.db",
   "chunk_size": 500,
   "search_top_k": 5,
@@ -122,7 +126,11 @@ Create `config.json`:
 
 ### Configuration Options
 
-- `documents_dir`: Directory containing markdown files
+- `document_patterns`: Array of document paths and glob patterns
+  - Supports directory paths: `"./documents"`
+  - Supports glob patterns: `"./docs/**/*.md"` (recursive)
+  - Multiple patterns: Index files from different locations
+  - **Note**: Old `documents_dir` field is still supported (automatically migrated)
 - `db_path`: Vector database file path
 - `chunk_size`: Document chunk size in characters
 - `search_top_k`: Number of search results to return
@@ -144,6 +152,19 @@ This is useful for:
 - Running multiple instances with different configurations
 - Testing different models or chunk sizes
 - Maintaining separate dev/test/prod configurations
+
+### Pattern Examples
+
+```json
+{
+  "document_patterns": [
+    "./documents",                    // All .md files in documents/
+    "./notes/**/*.md",                // Recursive search in notes/
+    "./projects/*/docs/*.md",         // docs/ in each project
+    "/path/to/external/docs"          // Absolute path
+  ]
+}
+```
 
 ## MCP Tools
 
@@ -195,7 +216,11 @@ Configure for your project's docs directory:
 
 ```json
 {
-  "documents_dir": "./docs",
+  "document_patterns": [
+    "./docs",
+    "./api-docs/**/*.md",
+    "./wiki/**/*.md"
+  ],
   "db_path": "./.devrag/vectors.db"
 }
 ```
@@ -455,7 +480,11 @@ Claude Codeで：
 
 ```json
 {
-  "documents_dir": "./documents",
+  "document_patterns": [
+    "./documents",
+    "./notes/**/*.md",
+    "./projects/backend/**/*.md"
+  ],
   "db_path": "./vectors.db",
   "chunk_size": 500,
   "search_top_k": 5,
@@ -472,7 +501,11 @@ Claude Codeで：
 
 ### 設定項目
 
-- `documents_dir`: マークダウンファイルを配置するディレクトリ
+- `document_patterns`: ドキュメントのパスとglobパターンの配列
+  - ディレクトリパス対応: `"./documents"`
+  - globパターン対応: `"./docs/**/*.md"` (再帰的)
+  - 複数パターン: 異なる場所からファイルをインデックス化
+  - **注意**: 旧形式の`documents_dir`もサポート（自動的に移行）
 - `db_path`: ベクトルデータベースのパス
 - `chunk_size`: ドキュメントのチャンクサイズ（文字数）
 - `search_top_k`: 検索結果の返却件数
@@ -494,6 +527,19 @@ devrag --config /path/to/custom-config.json
 - 異なる設定で複数のインスタンスを実行
 - 異なるモデルやチャンクサイズをテスト
 - 開発/テスト/本番環境の設定を分離
+
+### パターン例
+
+```json
+{
+  "document_patterns": [
+    "./documents",                    // documents/内の全.mdファイル
+    "./notes/**/*.md",                // notes/内を再帰的に検索
+    "./projects/*/docs/*.md",         // 各プロジェクトのdocs/
+    "/path/to/external/docs"          // 絶対パス
+  ]
+}
+```
 
 ## MCPツール
 
@@ -545,7 +591,11 @@ Model Context Protocolを通じて以下のツールを提供：
 
 ```json
 {
-  "documents_dir": "./docs",
+  "document_patterns": [
+    "./docs",
+    "./api-docs/**/*.md",
+    "./wiki/**/*.md"
+  ],
   "db_path": "./.devrag/vectors.db"
 }
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	fmt.Fprintf(os.Stderr, "[INFO] Configuration loaded successfully\n")
-	fmt.Fprintf(os.Stderr, "[INFO] Documents directory: %s\n", cfg.DocumentsDir)
+	fmt.Fprintf(os.Stderr, "[INFO] Document patterns: %v\n", cfg.DocumentPatterns)
 	fmt.Fprintf(os.Stderr, "[INFO] Database path: %s\n", cfg.DBPath)
 	fmt.Fprintf(os.Stderr, "[INFO] Model: %s (dimensions: %d)\n", cfg.Model.Name, cfg.Model.Dimensions)
 	fmt.Fprintf(os.Stderr, "[INFO] Device: %s\n", cfg.Compute.Device)
@@ -51,10 +51,12 @@ func main() {
 
 	// 4. Initialize components
 
-	// Ensure documents directory exists
-	if err := os.MkdirAll(cfg.DocumentsDir, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "[FATAL] Failed to create documents directory: %v\n", err)
-		os.Exit(1)
+	// Ensure base directories exist
+	baseDirs := cfg.GetBaseDirectories()
+	for _, dir := range baseDirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "[WARN] Failed to create directory %s: %v\n", dir, err)
+		}
 	}
 
 	// Initialize database

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,14 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 type Config struct {
-	DocumentsDir string `json:"documents_dir"`
-	DBPath       string `json:"db_path"`
-	ChunkSize    int    `json:"chunk_size"`
-	SearchTopK   int    `json:"search_top_k"`
-	Compute      struct {
+	// Deprecated: Use DocumentPatterns instead
+	DocumentsDir     string   `json:"documents_dir,omitempty"`
+	DocumentPatterns []string `json:"document_patterns,omitempty"`
+	DBPath           string   `json:"db_path"`
+	ChunkSize        int      `json:"chunk_size"`
+	SearchTopK       int      `json:"search_top_k"`
+	Compute          struct {
 		Device        string `json:"device"`
 		FallbackToCPU bool   `json:"fallback_to_cpu"`
 	} `json:"compute"`
@@ -24,10 +28,10 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	cfg := &Config{
-		DocumentsDir: "./documents",
-		DBPath:       "./vectors.db",
-		ChunkSize:    500,
-		SearchTopK:   5,
+		DocumentPatterns: []string{"./documents"},
+		DBPath:           "./vectors.db",
+		ChunkSize:        500,
+		SearchTopK:       5,
 	}
 	cfg.Compute.Device = "auto"
 	cfg.Compute.FallbackToCPU = true
@@ -66,6 +70,14 @@ func Load(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config: %w", err)
 	}
 
+	// First unmarshal to check which fields are present
+	var rawConfig map[string]interface{}
+	if err := json.Unmarshal(data, &rawConfig); err != nil {
+		fmt.Fprintf(os.Stderr, "[WARN] Invalid JSON in config.json: %v\n", err)
+		fmt.Fprintf(os.Stderr, "[WARN] Using default configuration\n")
+		return DefaultConfig(), nil
+	}
+
 	cfg := DefaultConfig()
 	if err := json.Unmarshal(data, cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "[WARN] Invalid JSON in %s: %v\n", configPath, err)
@@ -74,6 +86,22 @@ func Load(configPath string) (*Config, error) {
 	}
 
 	fmt.Fprintf(os.Stderr, "[INFO] Loaded configuration from %s\n", configPath)
+	// Migrate old format to new format
+	_, hasOldField := rawConfig["documents_dir"]
+	_, hasNewField := rawConfig["document_patterns"]
+
+	if hasOldField && !hasNewField {
+		fmt.Fprintf(os.Stderr, "[INFO] Migrating from documents_dir to document_patterns\n")
+		cfg.DocumentPatterns = []string{cfg.DocumentsDir}
+		cfg.DocumentsDir = "" // Clear deprecated field
+	}
+
+	// Validate that at least one pattern is configured
+	if len(cfg.DocumentPatterns) == 0 {
+		cfg.DocumentPatterns = []string{"./documents"}
+	}
+
+	fmt.Fprintf(os.Stderr, "[INFO] Loaded configuration from %s\n", configFile)
 	return cfg, nil
 }
 
@@ -102,5 +130,210 @@ func (c *Config) Validate() error {
 	if c.Model.Dimensions <= 0 {
 		return fmt.Errorf("model.dimensions must be positive")
 	}
+	if len(c.DocumentPatterns) == 0 {
+		return fmt.Errorf("at least one document pattern must be specified")
+	}
 	return nil
+}
+
+// GetDocumentFiles expands all document patterns and returns matching markdown files
+func (c *Config) GetDocumentFiles() ([]string, error) {
+	files := make(map[string]bool) // Use map to deduplicate
+
+	for _, pattern := range c.DocumentPatterns {
+		matches, err := c.expandPattern(pattern)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[WARN] Failed to expand pattern %s: %v\n", pattern, err)
+			continue
+		}
+		for _, match := range matches {
+			files[match] = true
+		}
+	}
+
+	// Convert map to slice
+	result := make([]string, 0, len(files))
+	for file := range files {
+		result = append(result, file)
+	}
+
+	return result, nil
+}
+
+// expandPattern expands a single pattern to matching markdown files
+// Supports both directory paths (e.g., "./docs") and glob patterns (e.g., "./docs/**/*.md")
+func (c *Config) expandPattern(pattern string) ([]string, error) {
+	var files []string
+
+	// Check if pattern looks like a directory (no wildcards and no .md extension)
+	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+		// Treat as directory - walk it for all .md files
+		err := filepath.Walk(pattern, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil // Continue despite errors
+			}
+			if !info.IsDir() && filepath.Ext(path) == ".md" {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return files, nil
+	}
+
+	// Pattern contains wildcards - need to handle ** specially
+	if strings.Contains(pattern, "**") {
+		return c.expandDoubleStarPattern(pattern)
+	}
+
+	// Simple glob pattern (no **)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter to only markdown files
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() && filepath.Ext(match) == ".md" {
+			files = append(files, match)
+		}
+	}
+
+	return files, nil
+}
+
+// expandDoubleStarPattern handles patterns with ** (recursive directory matching)
+func (c *Config) expandDoubleStarPattern(pattern string) ([]string, error) {
+	var files []string
+
+	// Split pattern at **
+	parts := strings.SplitN(pattern, "**", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ** pattern: %s", pattern)
+	}
+
+	baseDir := parts[0]
+	suffix := parts[1]
+
+	// Clean up baseDir
+	if baseDir == "" {
+		baseDir = "."
+	} else {
+		baseDir = strings.TrimSuffix(baseDir, string(filepath.Separator))
+	}
+
+	// Walk the base directory
+	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Continue despite errors
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Check if path matches the suffix pattern
+		if c.matchesSuffix(path, baseDir, suffix) {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+// matchesSuffix checks if a file path matches the suffix pattern after **
+func (c *Config) matchesSuffix(path, baseDir, suffix string) bool {
+	// Remove baseDir from path
+	relPath, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return false
+	}
+
+	// If suffix is empty or just a separator, match all .md files
+	if suffix == "" || suffix == string(filepath.Separator) || suffix == "/" {
+		return filepath.Ext(path) == ".md"
+	}
+
+	// Clean suffix
+	suffix = strings.TrimPrefix(suffix, string(filepath.Separator))
+	suffix = strings.TrimPrefix(suffix, "/")
+
+	// If suffix is just *.md, match all markdown files
+	if suffix == "*.md" {
+		return filepath.Ext(path) == ".md"
+	}
+
+	// Check if relPath matches the suffix pattern
+	matched, err := filepath.Match(suffix, filepath.Base(relPath))
+	if err != nil {
+		return false
+	}
+
+	if matched && filepath.Ext(path) == ".md" {
+		return true
+	}
+
+	// For patterns like "subdir/*.md", check full relative path
+	matched, err = filepath.Match(suffix, relPath)
+	if err != nil {
+		return false
+	}
+
+	return matched && filepath.Ext(path) == ".md"
+}
+
+// GetBaseDirectories returns the base directories from all patterns
+// This is useful for path validation
+func (c *Config) GetBaseDirectories() []string {
+	dirs := make(map[string]bool)
+
+	for _, pattern := range c.DocumentPatterns {
+		// Extract base directory from pattern
+		baseDir := c.extractBaseDir(pattern)
+		if baseDir != "" {
+			absDir, err := filepath.Abs(baseDir)
+			if err == nil {
+				dirs[absDir] = true
+			}
+		}
+	}
+
+	result := make([]string, 0, len(dirs))
+	for dir := range dirs {
+		result = append(result, dir)
+	}
+
+	return result
+}
+
+// extractBaseDir extracts the base directory from a pattern
+func (c *Config) extractBaseDir(pattern string) string {
+	// Find the first wildcard
+	wildcardIndex := strings.IndexAny(pattern, "*?")
+	if wildcardIndex == -1 {
+		// No wildcards - entire pattern is base directory
+		return pattern
+	}
+
+	// Get the directory part before the wildcard
+	baseDir := pattern[:wildcardIndex]
+	baseDir = filepath.Dir(baseDir)
+
+	if baseDir == "." {
+		return baseDir
+	}
+
+	return baseDir
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -18,8 +19,8 @@ func TestLoadConfig_NoFile(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	if cfg.DocumentsDir != "./documents" {
-		t.Errorf("Expected default documents_dir, got %s", cfg.DocumentsDir)
+	if len(cfg.DocumentPatterns) != 1 || cfg.DocumentPatterns[0] != "./documents" {
+		t.Errorf("Expected default document_patterns [./documents], got %v", cfg.DocumentPatterns)
 	}
 
 	if cfg.ChunkSize != 500 {
@@ -57,7 +58,7 @@ func TestLoadConfig_Valid(t *testing.T) {
 
 	// Create test config
 	testConfig := `{
-  "documents_dir": "./test_docs",
+  "document_patterns": ["./test_docs", "./other_docs/**/*.md"],
   "db_path": "./test.db",
   "chunk_size": 300,
   "search_top_k": 10,
@@ -80,8 +81,14 @@ func TestLoadConfig_Valid(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	if cfg.DocumentsDir != "./test_docs" {
-		t.Errorf("Expected documents_dir './test_docs', got %s", cfg.DocumentsDir)
+	if len(cfg.DocumentPatterns) != 2 {
+		t.Errorf("Expected 2 document patterns, got %d", len(cfg.DocumentPatterns))
+	}
+	if cfg.DocumentPatterns[0] != "./test_docs" {
+		t.Errorf("Expected first pattern './test_docs', got %s", cfg.DocumentPatterns[0])
+	}
+	if cfg.DocumentPatterns[1] != "./other_docs/**/*.md" {
+		t.Errorf("Expected second pattern './other_docs/**/*.md', got %s", cfg.DocumentPatterns[1])
 	}
 
 	if cfg.DBPath != "./test.db" {
@@ -224,8 +231,8 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	// Verify all default values
-	if cfg.DocumentsDir != "./documents" {
-		t.Errorf("Wrong default documents_dir: %s", cfg.DocumentsDir)
+	if len(cfg.DocumentPatterns) != 1 || cfg.DocumentPatterns[0] != "./documents" {
+		t.Errorf("Wrong default document_patterns: %v", cfg.DocumentPatterns)
 	}
 	if cfg.DBPath != "./vectors.db" {
 		t.Errorf("Wrong default db_path: %s", cfg.DBPath)
@@ -265,6 +272,35 @@ func TestLoadConfig_CustomPath(t *testing.T) {
 
 	// Load with custom path
 	cfg, err := Load(customConfigPath)
+func TestLoadConfig_BackwardsCompatibility(t *testing.T) {
+	// Test that old documents_dir format is migrated to document_patterns
+	tmpDir := t.TempDir()
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	os.Chdir(tmpDir)
+
+	// Create test config with old format
+	oldConfig := `{
+  "documents_dir": "./old_docs",
+  "db_path": "./test.db",
+  "chunk_size": 300,
+  "search_top_k": 10,
+  "compute": {
+    "device": "cpu",
+    "fallback_to_cpu": false
+  },
+  "model": {
+    "name": "test-model",
+    "dimensions": 256
+  }
+}`
+
+	if err := os.WriteFile("config.json", []byte(oldConfig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -389,4 +425,153 @@ func TestLoadConfig_RelativeAndAbsolutePaths(t *testing.T) {
 	if cfg.ChunkSize != 700 {
 		t.Errorf("Expected chunk_size 700 from absolute path, got %d", cfg.ChunkSize)
 	}
+	// Verify migration
+	if len(cfg.DocumentPatterns) != 1 {
+		t.Errorf("Expected 1 document pattern after migration, got %d", len(cfg.DocumentPatterns))
+	}
+	if cfg.DocumentPatterns[0] != "./old_docs" {
+		t.Errorf("Expected pattern './old_docs', got %s", cfg.DocumentPatterns[0])
+	}
+	if cfg.DocumentsDir != "" {
+		t.Errorf("Expected deprecated DocumentsDir to be cleared, got %s", cfg.DocumentsDir)
+	}
+}
+
+func TestGetDocumentFiles(t *testing.T) {
+	// Create temporary test directory structure
+	tmpDir := t.TempDir()
+
+	// Create test files
+	testFiles := []string{
+		"docs/file1.md",
+		"docs/subdir/file2.md",
+		"notes/file3.md",
+		"other/file4.txt", // not markdown
+	}
+
+	for _, file := range testFiles {
+		fullPath := filepath.Join(tmpDir, file)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte("# Test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name            string
+		patterns        []string
+		expectedCount   int
+		shouldContain   []string
+		shouldNotContain []string
+	}{
+		{
+			name:          "single directory pattern",
+			patterns:      []string{tmpDir + "/docs"},
+			expectedCount: 2,
+			shouldContain: []string{"file1.md", "file2.md"},
+		},
+		{
+			name:          "glob pattern with **",
+			patterns:      []string{tmpDir + "/docs/**/*.md"},
+			expectedCount: 2,
+			shouldContain: []string{"file1.md", "file2.md"},
+		},
+		{
+			name:          "multiple patterns",
+			patterns:      []string{tmpDir + "/docs", tmpDir + "/notes"},
+			expectedCount: 3,
+			shouldContain: []string{"file1.md", "file2.md", "file3.md"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				DocumentPatterns: tt.patterns,
+			}
+
+			files, err := cfg.GetDocumentFiles()
+			if err != nil {
+				t.Fatalf("GetDocumentFiles failed: %v", err)
+			}
+
+			if len(files) != tt.expectedCount {
+				t.Errorf("Expected %d files, got %d: %v", tt.expectedCount, len(files), files)
+			}
+
+			// Check that expected files are present
+			for _, expected := range tt.shouldContain {
+				found := false
+				for _, file := range files {
+					if contains(file, expected) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected to find file containing '%s', but it was not found in %v", expected, files)
+				}
+			}
+		})
+	}
+}
+
+func TestGetBaseDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name          string
+		patterns      []string
+		expectedCount int
+	}{
+		{
+			name:          "single directory",
+			patterns:      []string{tmpDir + "/docs"},
+			expectedCount: 1,
+		},
+		{
+			name:          "glob pattern",
+			patterns:      []string{tmpDir + "/docs/**/*.md"},
+			expectedCount: 1,
+		},
+		{
+			name:          "multiple patterns with subdirectory",
+			patterns:      []string{tmpDir + "/docs/**/*.md", tmpDir + "/docs/subdir/*.md"},
+			expectedCount: 2, // Different base directories (docs and docs/subdir)
+		},
+		{
+			name:          "multiple patterns different bases",
+			patterns:      []string{tmpDir + "/docs", tmpDir + "/notes"},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				DocumentPatterns: tt.patterns,
+			}
+
+			dirs := cfg.GetBaseDirectories()
+			if len(dirs) != tt.expectedCount {
+				t.Errorf("Expected %d base directories, got %d: %v", tt.expectedCount, len(dirs), dirs)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[len(s)-len(substr):] == substr || s[:len(substr)] == substr || containsMiddle(s, substr)))
+}
+
+func containsMiddle(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### **User description**
Changes:
- Add flag parsing in cmd/main.go to accept --config parameter
- Modify config.Load() to accept configPath parameter (defaults to "config.json")
- Add comprehensive tests for custom config path functionality
- Update README.md with documentation for --config flag (English and Japanese)

Benefits:
- Support running multiple instances with different configurations
- Enable testing different models or chunk sizes easily
- Allow separate dev/test/prod configurations
- Follow industry standard CLI patterns (docker, kubectl, git, etc.)

Tests added:
- TestLoadConfig_CustomPath: Verify custom config loading
- TestLoadConfig_CustomPath_NotFound: Test fallback to defaults
- TestLoadConfig_CustomPath_InvalidJSON: Test graceful degradation
- TestLoadConfig_RelativeAndAbsolutePaths: Test both path types


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `--config` CLI flag to specify custom configuration file path

- Modify `config.Load()` to accept configPath parameter with defaults

- Add four comprehensive tests for custom config path functionality

- Update README.md with CLI flag documentation (English and Japanese)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Arguments"] -- "--config flag" --> Main["cmd/main.go"]
  Main -- "configPath parameter" --> ConfigLoad["config.Load()"]
  ConfigLoad -- "custom or default path" --> ConfigFile["Configuration File"]
  ConfigFile -- "loaded config" --> App["Application"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add CLI flag parsing for config path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/main.go

<ul><li>Import <code>flag</code> package for CLI argument parsing<br> <li> Add flag parsing to accept <code>--config</code> parameter with default value <br><code>config.json</code><br> <li> Pass parsed configPath to <code>config.Load()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/3/files#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Support dynamic config file path parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config.go

<ul><li>Modify <code>Load()</code> function signature to accept <code>configPath</code> string parameter<br> <li> Add empty string check to default to <code>config.json</code> if not provided<br> <li> Update all file operations to use dynamic <code>configPath</code> instead of <br>hardcoded constant<br> <li> Only generate template file when using default <code>config.json</code> path<br> <li> Update all log messages to reference the actual config file path</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/3/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cd">+18/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_test.go</strong><dd><code>Add comprehensive custom config path tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config_test.go

<ul><li>Update existing tests to pass empty string <code>""</code> to <code>Load()</code> for default <br>behavior<br> <li> Add <code>TestLoadConfig_CustomPath()</code> to verify custom config file loading <br>with various settings<br> <li> Add <code>TestLoadConfig_CustomPath_NotFound()</code> to test fallback to defaults <br>when file missing<br> <li> Add <code>TestLoadConfig_CustomPath_InvalidJSON()</code> to test graceful <br>degradation with invalid JSON<br> <li> Add <code>TestLoadConfig_RelativeAndAbsolutePaths()</code> to verify both relative <br>and absolute path support</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/3/files#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62">+155/-2</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document --config flag in English and Japanese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add English documentation section for <code>--config</code> command-line option <br>with usage example<br> <li> Explain use cases for custom config paths (multiple instances, <br>testing, dev/test/prod separation)<br> <li> Add MCP server configuration example showing <code>--config</code> flag usage<br> <li> Add Japanese translation of command-line options section with <br>equivalent examples and use cases<br> <li> Add Japanese MCP server configuration example with <code>--config</code> flag</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/3/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

