### PR TITLE
Fix merge issues from PR #3 (--config CLI flag)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -32,7 +32,7 @@ func TestEndToEnd_FirstRun(t *testing.T) {
 
 	// Initialize components
 	cfg := config.DefaultConfig()
-	cfg.DocumentsDir = testDir
+	cfg.DocumentPatterns = []string{testDir}
 	cfg.DBPath = dbPath
 	cfg.ChunkSize = 100
 
@@ -94,7 +94,7 @@ func TestEndToEnd_Reindex(t *testing.T) {
 
 	// Initialize
 	cfg := config.DefaultConfig()
-	cfg.DocumentsDir = testDir
+	cfg.DocumentPatterns = []string{testDir}
 	cfg.DBPath = dbPath
 
 	db, err := vectordb.Init(dbPath)
@@ -165,7 +165,7 @@ func TestEndToEnd_MultipleFiles(t *testing.T) {
 
 	// Initialize
 	cfg := config.DefaultConfig()
-	cfg.DocumentsDir = testDir
+	cfg.DocumentPatterns = []string{testDir}
 	cfg.DBPath = dbPath
 
 	db, err := vectordb.Init(dbPath)
@@ -229,7 +229,7 @@ func TestEndToEnd_DeleteDocument(t *testing.T) {
 
 	// Initialize and index
 	cfg := config.DefaultConfig()
-	cfg.DocumentsDir = testDir
+	cfg.DocumentPatterns = []string{testDir}
 	cfg.DBPath = dbPath
 
 	db, err := vectordb.Init(dbPath)
@@ -302,7 +302,7 @@ func TestEndToEnd_Sync(t *testing.T) {
 
 	// Initialize
 	cfg := config.DefaultConfig()
-	cfg.DocumentsDir = testDir
+	cfg.DocumentPatterns = []string{testDir}
 	cfg.DBPath = dbPath
 
 	db, err := vectordb.Init(dbPath)
@@ -377,7 +377,7 @@ func TestEndToEnd_EmptyDirectory(t *testing.T) {
 
 	// Initialize
 	cfg := config.DefaultConfig()
-	cfg.DocumentsDir = testDir
+	cfg.DocumentPatterns = []string{testDir}
 	cfg.DBPath = dbPath
 
 	db, err := vectordb.Init(dbPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,7 +101,7 @@ func Load(configPath string) (*Config, error) {
 		cfg.DocumentPatterns = []string{"./documents"}
 	}
 
-	fmt.Fprintf(os.Stderr, "[INFO] Loaded configuration from %s\n", configFile)
+	fmt.Fprintf(os.Stderr, "[INFO] Loaded configuration from %s\n", configPath)
 	return cfg, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -245,33 +245,6 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_CustomPath(t *testing.T) {
-	// Create temporary directory for testing
-	tmpDir := t.TempDir()
-
-	// Create custom config file
-	customConfigPath := tmpDir + "/custom-config.json"
-	testConfig := `{
-  "documents_dir": "./custom_docs",
-  "db_path": "./custom.db",
-  "chunk_size": 1000,
-  "search_top_k": 20,
-  "compute": {
-    "device": "cuda",
-    "fallback_to_cpu": true
-  },
-  "model": {
-    "name": "custom-model",
-    "dimensions": 512
-  }
-}`
-
-	if err := os.WriteFile(customConfigPath, []byte(testConfig), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Load with custom path
-	cfg, err := Load(customConfigPath)
 func TestLoadConfig_BackwardsCompatibility(t *testing.T) {
 	// Test that old documents_dir format is migrated to document_patterns
 	tmpDir := t.TempDir()
@@ -300,14 +273,57 @@ func TestLoadConfig_BackwardsCompatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg, err := Load()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Verify migration
+	if len(cfg.DocumentPatterns) != 1 {
+		t.Errorf("Expected 1 document pattern after migration, got %d", len(cfg.DocumentPatterns))
+	}
+	if cfg.DocumentPatterns[0] != "./old_docs" {
+		t.Errorf("Expected pattern './old_docs', got %s", cfg.DocumentPatterns[0])
+	}
+	if cfg.DocumentsDir != "" {
+		t.Errorf("Expected deprecated DocumentsDir to be cleared, got %s", cfg.DocumentsDir)
+	}
+}
+
+func TestLoadConfig_CustomPath(t *testing.T) {
+	// Create temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Create custom config file
+	customConfigPath := tmpDir + "/custom-config.json"
+	testConfig := `{
+  "document_patterns": ["./custom_docs"],
+  "db_path": "./custom.db",
+  "chunk_size": 1000,
+  "search_top_k": 20,
+  "compute": {
+    "device": "cuda",
+    "fallback_to_cpu": true
+  },
+  "model": {
+    "name": "custom-model",
+    "dimensions": 512
+  }
+}`
+
+	if err := os.WriteFile(customConfigPath, []byte(testConfig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load with custom path
+	cfg, err := Load(customConfigPath)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// Verify custom values are loaded
-	if cfg.DocumentsDir != "./custom_docs" {
-		t.Errorf("Expected documents_dir './custom_docs', got %s", cfg.DocumentsDir)
+	if len(cfg.DocumentPatterns) != 1 || cfg.DocumentPatterns[0] != "./custom_docs" {
+		t.Errorf("Expected document_patterns ['./custom_docs'], got %v", cfg.DocumentPatterns)
 	}
 
 	if cfg.DBPath != "./custom.db" {
@@ -343,8 +359,8 @@ func TestLoadConfig_CustomPath_NotFound(t *testing.T) {
 	}
 
 	// Should return default config when file doesn't exist
-	if cfg.DocumentsDir != "./documents" {
-		t.Errorf("Expected default documents_dir, got %s", cfg.DocumentsDir)
+	if len(cfg.DocumentPatterns) != 1 || cfg.DocumentPatterns[0] != "./documents" {
+		t.Errorf("Expected default document_patterns, got %v", cfg.DocumentPatterns)
 	}
 
 	if cfg.ChunkSize != 500 {
@@ -359,7 +375,7 @@ func TestLoadConfig_CustomPath_InvalidJSON(t *testing.T) {
 	// Create invalid config file
 	customConfigPath := tmpDir + "/invalid-config.json"
 	invalidJSON := `{
-  "documents_dir": "./docs",
+  "document_patterns": ["./docs"],
   "invalid json here
 }`
 
@@ -374,8 +390,8 @@ func TestLoadConfig_CustomPath_InvalidJSON(t *testing.T) {
 	}
 
 	// Should have default values due to fallback
-	if cfg.DocumentsDir != "./documents" {
-		t.Errorf("Expected default documents_dir, got %s", cfg.DocumentsDir)
+	if len(cfg.DocumentPatterns) != 1 || cfg.DocumentPatterns[0] != "./documents" {
+		t.Errorf("Expected default document_patterns, got %v", cfg.DocumentPatterns)
 	}
 }
 
@@ -384,7 +400,7 @@ func TestLoadConfig_RelativeAndAbsolutePaths(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	testConfig := `{
-  "documents_dir": "./test_docs",
+  "document_patterns": ["./test_docs"],
   "db_path": "./test.db",
   "chunk_size": 700,
   "search_top_k": 15
@@ -424,16 +440,6 @@ func TestLoadConfig_RelativeAndAbsolutePaths(t *testing.T) {
 
 	if cfg.ChunkSize != 700 {
 		t.Errorf("Expected chunk_size 700 from absolute path, got %d", cfg.ChunkSize)
-	}
-	// Verify migration
-	if len(cfg.DocumentPatterns) != 1 {
-		t.Errorf("Expected 1 document pattern after migration, got %d", len(cfg.DocumentPatterns))
-	}
-	if cfg.DocumentPatterns[0] != "./old_docs" {
-		t.Errorf("Expected pattern './old_docs', got %s", cfg.DocumentPatterns[0])
-	}
-	if cfg.DocumentsDir != "" {
-		t.Errorf("Expected deprecated DocumentsDir to be cleared, got %s", cfg.DocumentsDir)
 	}
 }
 

--- a/internal/indexer/sync.go
+++ b/internal/indexer/sync.go
@@ -3,7 +3,6 @@ package indexer
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 )
 


### PR DESCRIPTION
### **User description**
## Summary
Fixes build and test failures introduced by merge conflicts in PR #3.

## Changes
- **config.go**: Fix undefined variable `configFile` → `configPath`
- **config_test.go**: Restore complete `TestLoadConfig_CustomPath` test (was truncated)
- **sync.go**: Remove unused `path/filepath` import
- **integration_test.go**: Update `DocumentsDir` → `DocumentPatterns` (6 occurrences)

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix undefined variable `configFile` → `configPath` in config.go

- Restore complete `TestLoadConfig_CustomPath` test (was truncated)

- Update integration tests: `DocumentsDir` → `DocumentPatterns` (6 occurrences)

- Remove unused `path/filepath` import from sync.go


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Merge Conflict Issues"] --> B["Variable Name Fix"]
  A --> C["Test Restoration"]
  A --> D["API Migration"]
  A --> E["Import Cleanup"]
  B --> F["config.go: configFile → configPath"]
  C --> G["config_test.go: Restore TestLoadConfig_CustomPath"]
  D --> H["integration_test.go: DocumentsDir → DocumentPatterns"]
  E --> I["sync.go: Remove unused import"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Fix undefined variable in config loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config.go

<ul><li>Fix undefined variable reference: <code>configFile</code> → <code>configPath</code> in fprintf <br>call<br> <li> Corrects variable name to match function parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/6/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_test.go</strong><dd><code>Restore and update config tests for new API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config_test.go

<ul><li>Restore complete <code>TestLoadConfig_CustomPath</code> test that was truncated<br> <li> Update test config to use <code>document_patterns</code> instead of deprecated <br><code>documents_dir</code><br> <li> Update all test assertions to verify <code>DocumentPatterns</code> array instead of <br><code>DocumentsDir</code> string<br> <li> Reorganize test functions for better logical flow</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/6/files#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62">+52/-46</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>integration_test.go</strong><dd><code>Update integration tests for DocumentPatterns API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integration_test.go

<ul><li>Update 6 test functions to use <code>DocumentPatterns</code> array instead of <br><code>DocumentsDir</code> string<br> <li> Affected tests: <code>TestEndToEnd_FirstRun</code>, <code>TestEndToEnd_Reindex</code>, <br><code>TestEndToEnd_MultipleFiles</code>, <code>TestEndToEnd_DeleteDocument</code>, <br><code>TestEndToEnd_Sync</code>, <code>TestEndToEnd_EmptyDirectory</code><br> <li> Change pattern: <code>cfg.DocumentsDir = testDir</code> → <code>cfg.DocumentPatterns = </code><br><code>[]string{testDir}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/6/files#diff-ed1088fda4ca38792b99302b355705eb525017fca294e83858422bb430d8cc59">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.go</strong><dd><code>Remove unused import statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/indexer/sync.go

<ul><li>Remove unused <code>path/filepath</code> import<br> <li> Cleanup from merge conflict resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/6/files#diff-fc633346efad6133f00c66cf7004ac41d5b3fbd196c6f2a8c6e0009eee2ff496">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

