### PR TITLE
Add update checker for new version notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ models/tokenizer.json
 # Claude Code user settings
 .mcp.json
 
+# MCP Registry tokens
+.mcpregistry_*
+
 # OS
 .DS_Store
 Thumbs.db

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="20" fill="url(#bg)"/>
+  <text x="50" y="62" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle">DR</text>
+  <circle cx="75" cy="25" r="8" fill="#22c55e"/>
+</svg>

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,15 +9,23 @@ import (
 	"github.com/tomohiro-owada/devrag/internal/embedder"
 	"github.com/tomohiro-owada/devrag/internal/indexer"
 	"github.com/tomohiro-owada/devrag/internal/mcp"
+	"github.com/tomohiro-owada/devrag/internal/updater"
 	"github.com/tomohiro-owada/devrag/internal/vectordb"
+	"github.com/tomohiro-owada/devrag/internal/version"
 )
 
 func main() {
 	// Parse command-line flags
 	configPath := flag.String("config", "config.json", "path to configuration file")
+	showVersion := flag.Bool("version", false, "show version and exit")
 	flag.Parse()
 
-	fmt.Fprintf(os.Stderr, "[INFO] DevRag starting...\n")
+	if *showVersion {
+		fmt.Printf("devrag version %s\n", version.Version)
+		os.Exit(0)
+	}
+
+	fmt.Fprintf(os.Stderr, "[INFO] DevRag v%s starting...\n", version.Version)
 
 	// 1. Load configuration
 	cfg, err := config.Load(*configPath)
@@ -37,6 +45,11 @@ func main() {
 	fmt.Fprintf(os.Stderr, "[INFO] Database path: %s\n", cfg.DBPath)
 	fmt.Fprintf(os.Stderr, "[INFO] Model: %s (dimensions: %d)\n", cfg.Model.Name, cfg.Model.Dimensions)
 	fmt.Fprintf(os.Stderr, "[INFO] Device: %s\n", cfg.Compute.Device)
+
+	// Check for updates (non-blocking, runs in background)
+	if cfg.IsUpdateCheckEnabled() {
+		go updater.CheckForUpdate(version.Version, "")
+	}
 
 	// 2. Download model files if needed
 	modelDir := "models"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DBPath           string   `json:"db_path"`
 	ChunkSize        int      `json:"chunk_size"`
 	SearchTopK       int      `json:"search_top_k"`
+	UpdateCheck      *bool    `json:"update_check,omitempty"`
 	Compute          struct {
 		Device        string `json:"device"`
 		FallbackToCPU bool   `json:"fallback_to_cpu"`
@@ -23,6 +24,14 @@ type Config struct {
 		Name       string `json:"name"`
 		Dimensions int    `json:"dimensions"`
 	} `json:"model"`
+}
+
+// IsUpdateCheckEnabled returns whether update checking is enabled (default: true)
+func (c *Config) IsUpdateCheckEnabled() bool {
+	if c.UpdateCheck == nil {
+		return true
+	}
+	return *c.UpdateCheck
 }
 
 // DefaultConfig returns default configuration

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,252 @@
+package updater
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	GitHubAPIURL     = "https://api.github.com/repos/tomohiro-owada/devrag/releases/latest"
+	CheckIntervalHrs = 24
+	CacheFileName    = ".devrag_update_check"
+)
+
+// semverRegex matches semantic versioning pattern (e.g., "1.2.3", "v1.2.3")
+var semverRegex = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)`)
+
+type GitHubRelease struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+type UpdateCache struct {
+	LastCheck       time.Time `json:"last_check"`
+	LatestVersion   string    `json:"latest_version"`
+	NotifiedVersion string    `json:"notified_version"`
+}
+
+// CheckForUpdate checks GitHub for a newer version
+// Errors are logged to stderr with debug context when DEVRAG_DEBUG is set
+func CheckForUpdate(currentVersion string, cacheDir string) {
+	debug := os.Getenv("DEVRAG_DEBUG") != ""
+
+	cache, err := loadCache(cacheDir)
+	if err != nil && debug {
+		fmt.Fprintf(os.Stderr, "[DEBUG] Failed to load update cache: %v\n", err)
+	}
+
+	// Skip if checked within the last 24 hours
+	if time.Since(cache.LastCheck) < time.Duration(CheckIntervalHrs)*time.Hour {
+		// Still notify if there's a newer version we haven't notified about
+		if cache.LatestVersion != "" && cache.NotifiedVersion != cache.LatestVersion {
+			newer, err := isNewerVersion(cache.LatestVersion, currentVersion)
+			if err != nil && debug {
+				fmt.Fprintf(os.Stderr, "[DEBUG] Version comparison failed: %v\n", err)
+			}
+			if newer {
+				printUpdateNotice(currentVersion, cache.LatestVersion)
+				cache.NotifiedVersion = cache.LatestVersion
+				if err := saveCache(cacheDir, cache); err != nil && debug {
+					fmt.Fprintf(os.Stderr, "[DEBUG] Failed to save update cache: %v\n", err)
+				}
+			}
+		}
+		return
+	}
+
+	// Fetch latest release from GitHub
+	release, err := fetchLatestRelease()
+	if err != nil {
+		if debug {
+			fmt.Fprintf(os.Stderr, "[DEBUG] Failed to fetch latest release: %v\n", err)
+		}
+		return
+	}
+
+	latestVersion, err := normalizeVersion(release.TagName)
+	if err != nil {
+		if debug {
+			fmt.Fprintf(os.Stderr, "[DEBUG] Invalid version tag %q: %v\n", release.TagName, err)
+		}
+		return
+	}
+
+	cache.LastCheck = time.Now()
+	cache.LatestVersion = latestVersion
+
+	newer, err := isNewerVersion(latestVersion, currentVersion)
+	if err != nil {
+		if debug {
+			fmt.Fprintf(os.Stderr, "[DEBUG] Version comparison failed: %v\n", err)
+		}
+		return
+	}
+
+	if newer {
+		printUpdateNotice(currentVersion, latestVersion)
+		cache.NotifiedVersion = latestVersion
+	}
+
+	if err := saveCache(cacheDir, cache); err != nil && debug {
+		fmt.Fprintf(os.Stderr, "[DEBUG] Failed to save update cache: %v\n", err)
+	}
+}
+
+func fetchLatestRelease() (*GitHubRelease, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	req, err := http.NewRequest("GET", GitHubAPIURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "devrag-update-checker")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var release GitHubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	if release.TagName == "" {
+		return nil, fmt.Errorf("empty tag_name in response")
+	}
+
+	return &release, nil
+}
+
+// normalizeVersion extracts and validates semantic version from tag
+func normalizeVersion(version string) (string, error) {
+	matches := semverRegex.FindStringSubmatch(version)
+	if matches == nil {
+		return "", fmt.Errorf("invalid semver format: %q", version)
+	}
+	return fmt.Sprintf("%s.%s.%s", matches[1], matches[2], matches[3]), nil
+}
+
+// isNewerVersion compares two semantic versions
+func isNewerVersion(latest, current string) (bool, error) {
+	latestNorm, err := normalizeVersion(latest)
+	if err != nil {
+		return false, fmt.Errorf("latest version: %w", err)
+	}
+
+	currentNorm, err := normalizeVersion(current)
+	if err != nil {
+		return false, fmt.Errorf("current version: %w", err)
+	}
+
+	latestParts, err := parseVersion(latestNorm)
+	if err != nil {
+		return false, fmt.Errorf("parse latest: %w", err)
+	}
+
+	currentParts, err := parseVersion(currentNorm)
+	if err != nil {
+		return false, fmt.Errorf("parse current: %w", err)
+	}
+
+	for i := 0; i < len(latestParts) && i < len(currentParts); i++ {
+		if latestParts[i] > currentParts[i] {
+			return true, nil
+		}
+		if latestParts[i] < currentParts[i] {
+			return false, nil
+		}
+	}
+
+	return len(latestParts) > len(currentParts), nil
+}
+
+func parseVersion(version string) ([]int, error) {
+	parts := strings.Split(version, ".")
+	result := make([]int, len(parts))
+
+	for i, part := range parts {
+		num, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid version part %q: %w", part, err)
+		}
+		if num < 0 {
+			return nil, fmt.Errorf("negative version part: %d", num)
+		}
+		result[i] = num
+	}
+
+	return result, nil
+}
+
+func printUpdateNotice(current, latest string) {
+	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprintf(os.Stderr, "[UPDATE] New version available: v%s (current: v%s)\n", latest, current)
+	fmt.Fprintf(os.Stderr, "[UPDATE] https://github.com/tomohiro-owada/devrag/releases/latest\n")
+	fmt.Fprintf(os.Stderr, "\n")
+}
+
+func getCachePath(cacheDir string) (string, error) {
+	if cacheDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get home directory: %w", err)
+		}
+		cacheDir = homeDir
+	}
+	return filepath.Join(cacheDir, CacheFileName), nil
+}
+
+func loadCache(cacheDir string) (*UpdateCache, error) {
+	cache := &UpdateCache{}
+
+	cachePath, err := getCachePath(cacheDir)
+	if err != nil {
+		return cache, err
+	}
+
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cache, nil // Not an error, just no cache yet
+		}
+		return cache, fmt.Errorf("read cache file: %w", err)
+	}
+
+	if err := json.Unmarshal(data, cache); err != nil {
+		return cache, fmt.Errorf("parse cache file: %w", err)
+	}
+
+	return cache, nil
+}
+
+func saveCache(cacheDir string, cache *UpdateCache) error {
+	cachePath, err := getCachePath(cacheDir)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return fmt.Errorf("marshal cache: %w", err)
+	}
+
+	if err := os.WriteFile(cachePath, data, 0644); err != nil {
+		return fmt.Errorf("write cache file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,135 @@
+package updater
+
+import "testing"
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"v1.2.0", "1.2.0", false},
+		{"1.2.0", "1.2.0", false},
+		{"v0.1.0", "0.1.0", false},
+		{"v10.20.30", "10.20.30", false},
+		{"invalid", "", true},
+		{"v1.2", "", true},
+		{"1.2.3-beta", "1.2.3", false}, // prefix match is ok
+		{"", "", true},
+		{"vX.Y.Z", "", true},
+	}
+
+	for _, tt := range tests {
+		result, err := normalizeVersion(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("normalizeVersion(%q) expected error, got %q", tt.input, result)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("normalizeVersion(%q) unexpected error: %v", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("normalizeVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		}
+	}
+}
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		latest   string
+		current  string
+		expected bool
+		wantErr  bool
+	}{
+		{"1.3.0", "1.2.0", true, false},
+		{"1.2.1", "1.2.0", true, false},
+		{"2.0.0", "1.9.9", true, false},
+		{"1.2.0", "1.2.0", false, false},
+		{"1.1.0", "1.2.0", false, false},
+		{"1.2.0", "1.2.1", false, false},
+		{"v1.3.0", "v1.2.0", true, false},
+		{"1.3.0", "v1.2.0", true, false},
+		{"invalid", "1.2.0", false, true},
+		{"1.2.0", "invalid", false, true},
+	}
+
+	for _, tt := range tests {
+		result, err := isNewerVersion(tt.latest, tt.current)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("isNewerVersion(%q, %q) expected error", tt.latest, tt.current)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("isNewerVersion(%q, %q) unexpected error: %v", tt.latest, tt.current, err)
+			}
+			if result != tt.expected {
+				t.Errorf("isNewerVersion(%q, %q) = %v, want %v", tt.latest, tt.current, result, tt.expected)
+			}
+		}
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []int
+		wantErr  bool
+	}{
+		{"1.2.0", []int{1, 2, 0}, false},
+		{"1.2.3", []int{1, 2, 3}, false},
+		{"10.20.30", []int{10, 20, 30}, false},
+		{"1.2.abc", nil, true},
+		{"1.2.-1", nil, true},
+		{"", []int{}, true},
+	}
+
+	for _, tt := range tests {
+		result, err := parseVersion(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseVersion(%q) expected error", tt.input)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("parseVersion(%q) unexpected error: %v", tt.input, err)
+			}
+			if len(result) != len(tt.expected) {
+				t.Errorf("parseVersion(%q) length = %d, want %d", tt.input, len(result), len(tt.expected))
+				continue
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("parseVersion(%q)[%d] = %d, want %d", tt.input, i, result[i], tt.expected[i])
+				}
+			}
+		}
+	}
+}
+
+func TestSemverRegex(t *testing.T) {
+	tests := []struct {
+		input   string
+		matches bool
+	}{
+		{"v1.2.3", true},
+		{"1.2.3", true},
+		{"v0.0.0", true},
+		{"v10.20.30", true},
+		{"1.2.3-beta", true},
+		{"v1.2.3-rc1", true},
+		{"v1.2", false},
+		{"v1", false},
+		{"invalid", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		matches := semverRegex.MatchString(tt.input)
+		if matches != tt.matches {
+			t.Errorf("semverRegex.MatchString(%q) = %v, want %v", tt.input, matches, tt.matches)
+		}
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the current version of DevRag
+// This is set at build time via -ldflags
+var Version = "1.2.1"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.tomohiro-owada/devrag",
+  "description": "Lightweight local RAG MCP server. 40x token reduction.",
+  "repository": {
+    "url": "https://github.com/tomohiro-owada/devrag",
+    "source": "github"
+  },
+  "version": "1.2.1",
+  "packages": []
+}


### PR DESCRIPTION
### **User description**
## Summary

- 起動時にGitHub Releases APIをチェックし、新バージョンがあればstderrに通知
- 24時間キャッシュで不要なAPIリクエストを抑制
- `--version`フラグでバージョン表示
- `update_check: false`で無効化可能

## Changes

| File | Description |
|------|-------------|
| `internal/updater/updater.go` | GitHub API呼び出し、バージョン比較、キャッシュ処理 |
| `internal/updater/updater_test.go` | ユニットテスト |
| `internal/version/version.go` | バージョン定数 |
| `internal/config/config.go` | `update_check`オプション追加 |
| `cmd/main.go` | 起動時チェック統合、`--version`フラグ |

## Example Output

```
[UPDATE] New version available: v1.3.0 (current: v1.2.0)
[UPDATE] https://github.com/tomohiro-owada/devrag/releases/latest
```

## Test plan

- [x] `go test ./internal/updater/...` パス
- [x] `devrag -version` でバージョン表示確認
- [ ] 新バージョンリリース後に通知表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add GitHub Releases API integration for version update checking

- Implement 24-hour cache to minimize API requests

- Add `--version` flag to display current version

- Add `update_check` config option to enable/disable checking

- Display update notifications via stderr when new version available


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Application Startup"] --> B["Check update_check Config"]
  B --> C["Background Update Check"]
  C --> D["GitHub Releases API"]
  D --> E["Version Comparison"]
  E --> F["Cache Management"]
  F --> G["Notify User"]
  H["--version Flag"] --> I["Display Current Version"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Integrate update checker and version flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/main.go

<ul><li>Import <code>updater</code> and <code>version</code> packages<br> <li> Add <code>--version</code> flag to display current version and exit<br> <li> Include version in startup log message<br> <li> Call <code>updater.CheckForUpdate()</code> in background if enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/8/files#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>updater.go</strong><dd><code>Implement GitHub update checker with caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/updater/updater.go

<ul><li>Implement <code>CheckForUpdate()</code> function to check GitHub Releases API<br> <li> Add version comparison logic with semantic versioning support<br> <li> Implement 24-hour cache mechanism to reduce API calls<br> <li> Fetch latest release from GitHub and notify user if newer version <br>available<br> <li> Handle version normalization and parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/8/files#diff-07f86aa363d0be00f9de8b4134d96188f3923b9557bc3428c65c8541027ea68d">+172/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>version.go</strong><dd><code>Add version constant package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/version/version.go

<ul><li>Create new version package with Version constant<br> <li> Set default version to "1.2.0"<br> <li> Support build-time version override via ldflags</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/8/files#diff-8aa632a6f4ad2a3a7fef52661816aa3977f23c0673ef29633c01116fee6745c6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add update check configuration option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/config/config.go

<ul><li>Add <code>UpdateCheck</code> optional boolean field to Config struct<br> <li> Implement <code>IsUpdateCheckEnabled()</code> method with default true behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/8/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cd">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.json</strong><dd><code>Add MCP server configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server.json

<ul><li>Add MCP server configuration file with metadata<br> <li> Define server name, description, and repository information<br> <li> Set version to "1.2.0"</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/8/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>updater_test.go</strong><dd><code>Add unit tests for updater functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/updater/updater_test.go

<ul><li>Add unit tests for <code>normalizeVersion()</code> function<br> <li> Add unit tests for <code>isNewerVersion()</code> semantic version comparison<br> <li> Add unit tests for <code>parseVersion()</code> version parsing logic</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/8/files#diff-b11a45b10577718a760d7e119f1936e68caeadb3fb5c9f2f32d000d2213f7be3">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

