### PR TITLE
Make physical file deletion optional in delete_document tool

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -156,10 +156,13 @@ func (s *MCPServer) handleListDocuments(ctx context.Context, request mcp.CallToo
 func (s *MCPServer) registerDeleteDocumentTool() {
 	tool := mcp.NewTool(
 		"delete_document",
-		mcp.WithDescription("ドキュメントをDBとファイルシステムの両方から削除"),
+		mcp.WithDescription("ドキュメントをインデックスから削除。delete_file=trueの場合は物理ファイルも削除"),
 		mcp.WithString("filename",
 			mcp.Required(),
 			mcp.Description("削除するファイル名"),
+		),
+		mcp.WithBoolean("delete_file",
+			mcp.Description("物理ファイルも削除するかどうか（デフォルト: false）"),
 		),
 	)
 
@@ -172,19 +175,33 @@ func (s *MCPServer) handleDeleteDocument(ctx context.Context, request mcp.CallTo
 		return mcp.NewToolResultError("filename is required"), nil
 	}
 
+	deleteFile := request.GetBool("delete_file", false)
+
+	// Validate path to prevent path traversal
+	if err := validatePath(filename, s.config.GetBaseDirectories()); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
+	}
+
 	// Delete from database
 	if err := s.db.DeleteDocument(filename); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to delete from database: %v", err)), nil
 	}
 
-	// Delete file (filename is the full path)
-	if err := os.Remove(filename); err != nil {
-		fmt.Fprintf(os.Stderr, "[WARN] Failed to delete file: %v\n", err)
+	// Delete physical file only if explicitly requested
+	fileDeleted := false
+	if deleteFile {
+		if err := os.Remove(filename); err != nil {
+			// Log warning but don't fail since DB deletion succeeded
+			fmt.Fprintf(os.Stderr, "[WARN] Failed to delete file: %v\n", err)
+		} else {
+			fileDeleted = true
+		}
 	}
 
 	return mcp.NewToolResultJSON(map[string]interface{}{
-		"success": true,
-		"message": "Document deleted successfully",
+		"success":      true,
+		"message":      "Document deleted successfully",
+		"file_deleted": fileDeleted,
 	})
 }
 


### PR DESCRIPTION
## Summary

Make physical file deletion optional in the `delete_document` tool. Previously, deleting a document always removed both the index entry and the physical file. Now, by default, only the index is deleted, preserving the physical file.

### Changes
- Add `delete_file` boolean parameter (default: `false`)
- Only delete physical file when `delete_file=true` is explicitly set
- Add `validatePath` check to prevent path traversal attacks
- Return actual deletion result in `file_deleted` response field

### Usage

```json
// Delete index only (physical file remains)
{"filename": "/path/to/doc.md"}

// Delete both index and physical file
{"filename": "/path/to/doc.md", "delete_file": true}
```

### Response

```json
{
  "success": true,
  "message": "Document deleted successfully",
  "file_deleted": false  // true only when file was actually deleted
}
```

## Test Plan
- [x] Verify `delete_document` without `delete_file` only removes index
- [x] Verify physical file remains after index-only deletion
- [x] Verify `delete_document` with `delete_file=true` removes both index and file
- [x] Verify `file_deleted` field reflects actual deletion result

---

## 概要

`delete_document` ツールで物理ファイルの削除をオプション化しました。従来はドキュメント削除時にインデックスと物理ファイルの両方が削除されていましたが、デフォルトではインデックスのみを削除し、物理ファイルを保持するようになりました。

### 変更内容
- `delete_file` booleanパラメータを追加（デフォルト: `false`）
- `delete_file=true` が明示的に指定された場合のみ物理ファイルを削除
- パストラバーサル攻撃防止のため `validatePath` チェックを追加
- レスポンスの `file_deleted` フィールドに実際の削除結果を返すように修正

### 使用方法

```json
// インデックスのみ削除（物理ファイルは残る）
{"filename": "/path/to/doc.md"}

// インデックスと物理ファイル両方を削除
{"filename": "/path/to/doc.md", "delete_file": true}
```

### レスポンス

```json
{
  "success": true,
  "message": "Document deleted successfully",
  "file_deleted": false  // 実際にファイルが削除された場合のみ true
}
```

## テスト計画
- [x] `delete_file` 未指定時にインデックスのみ削除されることを確認
- [x] インデックス削除後も物理ファイルが残ることを確認
- [x] `delete_file=true` 指定時にインデックスと物理ファイル両方が削除されることを確認
- [x] `file_deleted` フィールドが実際の削除結果を反映することを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)