### PR TITLE
Add comprehensive unit tests for MCP tools

### DIFF
--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -429,11 +429,14 @@ func TestHandleDeleteDocument_MissingFilename(t *testing.T) {
 }
 
 func TestHandleDeleteDocument_NotFound(t *testing.T) {
-	server, _ := testHelper(t)
+	server, tmpDir := testHelper(t)
 	ctx := context.Background()
 
+	// Use a path within the valid directory but file doesn't exist in DB
+	filePath := filepath.Join(tmpDir, "docs", "nonexistent.md")
+
 	request := createTestRequest(map[string]interface{}{
-		"filename": "nonexistent.md",
+		"filename": filePath,
 	})
 	result, err := server.handleDeleteDocument(ctx, request)
 
@@ -446,12 +449,31 @@ func TestHandleDeleteDocument_NotFound(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteDocument_Success(t *testing.T) {
+func TestHandleDeleteDocument_InvalidPath(t *testing.T) {
+	server, _ := testHelper(t)
+	ctx := context.Background()
+
+	// Try to delete a file outside the configured directories
+	request := createTestRequest(map[string]interface{}{
+		"filename": "/tmp/outside.md",
+	})
+	result, err := server.handleDeleteDocument(ctx, request)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if !result.IsError {
+		t.Error("Expected error result for invalid path")
+	}
+}
+
+func TestHandleDeleteDocument_Success_DBOnly(t *testing.T) {
 	server, tmpDir := testHelper(t)
 	ctx := context.Background()
 
 	// Create and index a document
-	filePath := createTestMarkdown(t, tmpDir, "docs/todelete.md", "# To Delete\n\nThis will be deleted.")
+	filePath := createTestMarkdown(t, tmpDir, "docs/todelete.md", "# To Delete\n\nThis will be deleted from DB only.")
 	if err := server.indexer.IndexFile(filePath); err != nil {
 		t.Fatalf("Failed to index: %v", err)
 	}
@@ -462,7 +484,7 @@ func TestHandleDeleteDocument_Success(t *testing.T) {
 		t.Fatalf("Expected 1 document before delete, got %d", len(docs))
 	}
 
-	// Delete the document
+	// Delete the document (delete_file defaults to false)
 	request := createTestRequest(map[string]interface{}{
 		"filename": filePath,
 	})
@@ -482,9 +504,52 @@ func TestHandleDeleteDocument_Success(t *testing.T) {
 		t.Errorf("Expected 0 documents after delete, got %d", len(docs))
 	}
 
+	// Verify file still exists on filesystem (delete_file=false)
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Error("Expected file to remain on filesystem when delete_file=false")
+	}
+}
+
+func TestHandleDeleteDocument_Success_WithFileDelete(t *testing.T) {
+	server, tmpDir := testHelper(t)
+	ctx := context.Background()
+
+	// Create and index a document
+	filePath := createTestMarkdown(t, tmpDir, "docs/todelete.md", "# To Delete\n\nThis will be fully deleted.")
+	if err := server.indexer.IndexFile(filePath); err != nil {
+		t.Fatalf("Failed to index: %v", err)
+	}
+
+	// Verify document exists
+	docs, _ := server.db.ListDocuments()
+	if len(docs) != 1 {
+		t.Fatalf("Expected 1 document before delete, got %d", len(docs))
+	}
+
+	// Delete the document with delete_file=true
+	request := createTestRequest(map[string]interface{}{
+		"filename":    filePath,
+		"delete_file": true,
+	})
+	result, err := server.handleDeleteDocument(ctx, request)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if result.IsError {
+		t.Errorf("Expected success, got error: %v", result)
+	}
+
+	// Verify document is deleted from database
+	docs, _ = server.db.ListDocuments()
+	if len(docs) != 0 {
+		t.Errorf("Expected 0 documents after delete, got %d", len(docs))
+	}
+
 	// Verify file is deleted from filesystem
 	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
-		t.Error("Expected file to be deleted from filesystem")
+		t.Error("Expected file to be deleted from filesystem when delete_file=true")
 	}
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- Add comprehensive unit tests for all 7 MCP tools
- Cover search, index_markdown, list_documents, delete_document, reindex_document, add_frontmatter, and update_frontmatter
- Include tests for the new `delete_file` parameter in delete_document tool
- Add validatePath helper function tests for path traversal prevention

## Changes
- **New file:** `internal/mcp/tools_test.go` (26 test cases)

### Test Coverage

| Tool | Test Cases |
|------|------------|
| `validatePath` | Valid path, subdirectory path, outside directory, path traversal attempt |
| `search` | Missing query, empty query, successful search, top_k parameter, directory/file filters |
| `index_markdown` | Missing filepath, invalid path, successful indexing, file not found |
| `list_documents` | Empty list, list with documents |
| `delete_document` | Missing filename, not found, invalid path, DB-only delete (default), delete with file removal |
| `reindex_document` | Missing filename, not in DB, successful reindex |
| `add_frontmatter` | Missing filepath, invalid path, successful addition, already exists error |
| `update_frontmatter` | Missing filepath, invalid path, successful update, add when not existing |

## Test plan
- [x] All 26 tests pass with `go test ./internal/mcp/ -v`
- [x] Tests cover both success and error cases for each tool
- [x] Path traversal attack prevention is tested
- [x] New `delete_file` parameter behavior is verified (default: false)


---

## 概要
- 全7つのMCPツールに対する包括的なユニットテストを追加
- search, index_markdown, list_documents, delete_document, reindex_document, add_frontmatter, update_frontmatterをカバー
- delete_documentツールの新しい`delete_file`パラメータのテストを含む
- パストラバーサル防止のためのvalidatePathヘルパー関数のテストを追加

## 変更内容
- **新規ファイル:** `internal/mcp/tools_test.go`（26テストケース）

### テストカバレッジ

| ツール | テストケース |
|--------|------------|
| `validatePath` | 有効なパス、サブディレクトリ、ディレクトリ外、パストラバーサル試行 |
| `search` | クエリ未指定、空クエリ、正常検索、top_kパラメータ、ディレクトリ/ファイルフィルター |
| `index_markdown` | パス未指定、無効パス、正常インデックス、ファイル不存在 |
| `list_documents` | 空リスト、ドキュメント有りリスト |
| `delete_document` | ファイル名未指定、存在しない、無効パス、DBのみ削除（デフォルト）、ファイル削除あり |
| `reindex_document` | ファイル名未指定、DB未登録、正常再インデックス |
| `add_frontmatter` | パス未指定、無効パス、正常追加、既存時エラー |
| `update_frontmatter` | パス未指定、無効パス、正常更新、未存在時は追加 |

## テスト計画
- [x] `go test ./internal/mcp/ -v` で全26テストがパス
- [x] 各ツールの正常系・異常系をカバー
- [x] パストラバーサル攻撃対策をテスト
- [x] 新しい`delete_file`パラメータの動作を検証（デフォルト: false）


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive unit tests for all 7 MCP tools

- Cover search, index_markdown, list_documents, delete_document, reindex_document, add_frontmatter, update_frontmatter

- Include tests for delete_file parameter behavior (DB-only vs full deletion)

- Add validatePath helper function tests for path traversal prevention


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] --> B["validatePath Tests"]
  A --> C["search Tool Tests"]
  A --> D["index_markdown Tool Tests"]
  A --> E["list_documents Tool Tests"]
  A --> F["delete_document Tool Tests"]
  A --> G["reindex_document Tool Tests"]
  A --> H["add_frontmatter Tool Tests"]
  A --> I["update_frontmatter Tool Tests"]
  B -- "4 test cases" --> J["Path validation"]
  C -- "5 test cases" --> K["Query validation & filtering"]
  D -- "4 test cases" --> L["File indexing"]
  E -- "2 test cases" --> M["Document listing"]
  F -- "5 test cases" --> N["Delete with delete_file param"]
  G -- "3 test cases" --> O["Document reindexing"]
  H -- "4 test cases" --> P["Frontmatter addition"]
  I -- "4 test cases" --> Q["Frontmatter updates"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tools_test.go</strong><dd><code>Comprehensive unit tests for all MCP tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/mcp/tools_test.go

<ul><li>New comprehensive test file with 26 test cases covering all MCP tools<br> <li> Helper functions: <code>testHelper()</code> for test server initialization, <br><code>createTestRequest()</code> for request creation, <code>createTestMarkdown()</code> for <br>test file creation<br> <li> validatePath tests: valid paths, subdirectories, path traversal <br>prevention, outside directory detection<br> <li> search tool tests: missing/empty query validation, successful search, <br>top_k parameter, directory/file filters<br> <li> index_markdown tests: missing filepath, invalid path, successful <br>indexing, file not found scenarios<br> <li> list_documents tests: empty list and populated list scenarios<br> <li> delete_document tests: missing filename, not found, invalid path, <br>DB-only deletion (default), full deletion with file removal<br> <li> reindex_document tests: missing filename, not in DB, successful <br>reindex with file modification<br> <li> add_frontmatter tests: missing filepath, invalid path, successful <br>addition, existing frontmatter error handling<br> <li> update_frontmatter tests: missing filepath, invalid path, successful <br>update, adding frontmatter when not existing</ul>


</details>


  </td>
  <td><a href="https://github.com/tomohiro-owada/devrag/pull/12/files#diff-2f42cc8f75783922e75c688b6e0ec487a0f818d52974310950a2f8fd9de6a4bd">+854/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

