### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ When using Claude Code, reading documents with the Read tool consumes massive am
 - ⚡ **Fast** - Auto GPU/CPU detection, incremental sync
 - 🌐 **Multilingual** - Supports 100+ languages including Japanese & English
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tomohiro-owada-devrag).
+
 ## Quick Start
 
 ### 1. Download Binary


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tomohiro-owada-devrag).